### PR TITLE
changed termii url

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const TERMII_URL = "https://termii.com/api/sms/send";
+const TERMII_URL = "https://api.ng.termii.com";
 
 const Termii = () => {
   let data = {


### PR DESCRIPTION
the api url has been changed to the one used in the termii api documentation